### PR TITLE
[AI] 추천 리스트 다양성 보장(타입별 최소 1개) 후처리 로직 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ moard-model/
 │   ├── agents.py              # DQN 에이전트 구현
 │   ├── envs.py                # 추천 환경 구현
 │   ├── embedders.py           # 임베딩 모듈
+│   ├── rec_utils.py # 후처리 로직 및 Q값 계산 도우미
 │   ├── rec_context.py         # 추천 컨텍스트 관리
 │   ├── registry.py            # 컴포넌트 레지스트리
 │   ├── rewards.py             # 보상 함수 구현
@@ -46,10 +47,12 @@ moard-model/
 
 ## 주요 기능
 
-- 강화학습 기반 추천 시스템 구현
+- QueryAwareCandidateGenerator: 쿼리(keyword) 기반 후보 생성
 - DQN 에이전트를 통한 최적 추천 전략 학습
-- 사용자-아이템 상호작용 환경 시뮬레이션
-- 실험 설정 및 결과 관리
+- 추천 리스트 다양성 보장(타입별 최소 1개) 후처리 로직
+- 보상 함수를 통한 추천 품질 평가 (클릭 + 체류시간 기반 가중 보상)
+- 콜드 스타트 상황 처리
+- 최대 스텝 수 제한
 
 ## 설치 방법
 

--- a/components/agents.py
+++ b/components/agents.py
@@ -1,7 +1,9 @@
 import random
-from typing import List, Dict
+import numpy as np
 import torch
 import torch.nn.functional as F
+
+from typing import List, Dict
 from components.base import BaseAgent
 from components.registry import register
 from models.q_network import QNetwork
@@ -113,8 +115,8 @@ class DQNAgent(BaseAgent):
         )
         next_states, next_cands_embs = next_info
 
-        us = torch.FloatTensor(user_states).to(self.device)
-        ce = torch.FloatTensor(content_embs).to(self.device)
+        us = torch.FloatTensor(np.array(user_states)).to(self.device)
+        ce = torch.FloatTensor(np.array(content_embs)).to(self.device)
         rs = torch.FloatTensor(rewards).unsqueeze(1).to(self.device)
         ds = torch.FloatTensor(dones).unsqueeze(1).to(self.device)
 
@@ -131,7 +133,7 @@ class DQNAgent(BaseAgent):
                 continue
             usn = torch.FloatTensor(ns).unsqueeze(0).to(self.device)
             usn_rep = usn.repeat(len(all_embs), 1)
-            cen = torch.FloatTensor(all_embs).to(self.device)
+            cen = torch.FloatTensor(np.array(all_embs)).to(self.device)
             with torch.no_grad():
                 qn = self.target_q_net(usn_rep, cen).squeeze(1)
             max_next_q_list.append(qn.max())

--- a/components/rec_utils.py
+++ b/components/rec_utils.py
@@ -1,0 +1,117 @@
+import numpy as np
+from typing import List, Tuple, Dict, Any
+
+
+def enforce_type_constraint(
+    q_values: Dict[str, List[float]], top_k: int = 6
+) -> List[Tuple[str, int]]:
+    """
+    타입별 Q값 리스트가 담긴 q_values를 받아,
+    상위 Q 순으로 top_k 개를 뽑되, 누락된 타입이 있으면 해당 타입 중
+    가장 높은 Q값 아이템을 끼워넣어 최종 (ctype, idx) 리스트를 반환합니다.
+
+    Args:
+        q_values: {
+            'youtube': [q0, q1, q2, ...],
+            'blog':    [q0, q1, q2, ...],
+            'news':    [q0, q1, q2, ...],
+            ...
+        }
+        top_k: 최종 추천 개수 (예: 6)
+
+    Returns:
+        List of (ctype, idx) 튜플, 길이 == top_k.
+        각 튜플은 “해당 타입 리스트 내에서 인덱스 idx”를 가리킵니다.
+    """
+    # 1) 모든 (ctype, idx, q) 튜플을 평탄화
+    all_items: List[Tuple[str, int, float]] = []
+    for ctype, q_list in q_values.items():
+        for idx, qv in enumerate(q_list):
+            all_items.append((ctype, idx, qv))
+
+    # 2) Q값 기준으로 내림차순 정렬
+    all_items.sort(key=lambda x: x[2], reverse=True)
+
+    # 3) 상위 top_k 개 선택 (임시 리스트)
+    selected = all_items[:top_k]
+
+    # 4) 현재 포함된 타입 집합
+    included_types = {ctype for ctype, _, _ in selected}
+
+    # 5) 누락된 타입 파악
+    missing_types = set(q_values.keys()) - included_types
+
+    # 6) 누락 타입마다 한 개씩 보충
+    #    - 각 누락 타입의 Q값 리스트에서 가장 큰 Q값을 가진 아이템을 찾아 selected에 삽입
+    #    - 그 자리에 있던 최하위 항목(6번째)과 교체
+    #    - 단, 해당 타입 리스트가 비어 있으면 무시
+    for mtype in missing_types:
+        q_list = q_values.get(mtype, [])
+        if not q_list:
+            continue
+        # 해당 타입 내에서 가장 큰 Q값의 인덱스 찾기
+        best_idx = int(np.argmax(q_list))
+        best_q = q_list[best_idx]
+        # 이미 selected에 포함된 같은 (ctype, idx)인지 확인
+        if any(ctype == mtype and idx == best_idx for ctype, idx, _ in selected):
+            continue
+        # 마지막 원소(최하위)를 제거하고 새 아이템 삽입
+        # - 제거할 인덱스: selected[top_k-1]
+        selected[-1] = (mtype, best_idx, best_q)
+        # 다시 정렬하여 최종 top_k 유지
+        selected.sort(key=lambda x: x[2], reverse=True)
+
+    # 7) 최종 결과를 (ctype, idx) 튜플 리스트로 반환
+    return [(ctype, idx) for ctype, idx, _ in selected]
+
+
+def compute_all_q_values(
+    state: Any, cand_dict: Dict[str, List[Dict[str, Any]]], embedder: Any, agent: Any
+) -> Dict[str, List[float]]:
+    """
+    현재 상태(state)와 후보 딕셔너리(cand_dict)를 받아,
+    각 타입별 후보들의 Q값 리스트를 반환합니다.
+
+    Args:
+        state: 현재 사용자 임베딩 벡터 (np.ndarray 등)
+        cand_dict: {
+            'youtube': [content0, content1, ...],
+            'blog':    [content0, content1, ...],
+            'news':    [content0, content1, ...],
+            ...
+        }
+        embedder: 콘텐츠 임베딩을 생성하는 객체 (embedder.embed_content 메서드 사용)
+        agent: Q-network가 포함된 에이전트 (agent.q_net 호출)
+
+    Returns:
+        {
+            'youtube': [q0, q1, ...],
+            'blog':    [q0, q1, ...],
+            'news':    [q0, q1, ...],
+            ...
+        }
+    """
+    q_values: Dict[str, List[float]] = {}
+    # 모든 후보 타입별로 반복
+    for ctype, contents in cand_dict.items():
+        # 1) 각 콘텐츠 임베딩 리스트 생성
+        content_embs = [embedder.embed_content(c) for c in contents]  # List[np.ndarray]
+        if not content_embs:
+            q_values[ctype] = []
+            continue
+        # 2) 배치 형태로 Q-network 호출
+        #    - state 벡터를 각 콘텐츠 수만큼 반복 복제
+        import torch
+
+        us = torch.FloatTensor(state).unsqueeze(0)  # shape: (1, user_dim)
+        us_rep = us.repeat(len(content_embs), 1).to(agent.device)
+        ce = torch.stack([torch.FloatTensor(e) for e in content_embs]).to(
+            agent.device
+        )  # shape: (N, content_dim)
+
+        with torch.no_grad():
+            q_out = agent.q_net(us_rep, ce).squeeze(1)  # shape: (N,)
+        q_list = q_out.cpu().numpy().tolist()
+        q_values[ctype] = q_list
+
+    return q_values

--- a/config/experiment.yaml
+++ b/config/experiment.yaml
@@ -41,6 +41,7 @@ experiment:
   total_episodes: 20
   max_recommendations: 6
   seeds: [0]
+  result_log_path: "experiment_results.log"
 
 replay:
   capacity: 10000


### PR DESCRIPTION
## 관련 이슈
- closed #15 

## 작업 내용
- [x] `components/rec_utils.py` (또는 적절한 유틸 파일) 생성  
- [x] `ExperimentRunner.run_single` 내 추천 루프 수정  
- [x] `RecEnv.step()` 호출 시, `action` 인자로 `(ctype, idx)` 리스트 대신 단일 튜플만 처리하도록 함  
- [x] Q값 계산 로직 보조 함수 추가  
- [x] 문서화